### PR TITLE
Moved zone firewall cleanup to be before firewall rule cleanup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,12 @@
       var: lines
     when: firewall_commands|length > 0
 
+  - name: Display cleanup firewall zone lines
+    vars:
+      lines: "{{ lookup('template', 'zones_firewall_cleanup.j2').splitlines() }}"
+    debug:
+      var: lines
+
   - name: Display cleanup lines
     vars:
       lines: "{{ lookup('template', 'firewall_cleanup.j2').splitlines() }}"
@@ -130,6 +136,11 @@
     edgeos_config:
       lines: "{{ firewall_commands }}"
     when: firewall_commands|length > 0
+
+  - name: Clean up zone firewall associations that are not in config
+    edgeos_config:
+      lines: "{{ lookup('template', 'zones_firewall_cleanup.j2').splitlines() }}"
+    when: firewall_cleanup|bool
 
   - name: Clean up firewall rule sets and content that are not in config
     edgeos_config:

--- a/templates/firewall.j2
+++ b/templates/firewall.j2
@@ -1,4 +1,5 @@
 {% if firewall_cleanup %}
+{% include 'zones_firewall_cleanup.j2' %}
 {% include 'firewall_cleanup.j2' %}
 {% endif %}
 {% if firewall_process_rules %}

--- a/templates/zones.j2
+++ b/templates/zones.j2
@@ -20,22 +20,10 @@ set zone-policy zone {{ zone.name }} {{ property }}
 {% if target_zone != zone.name %}
 {% if zone_ruleset in firewall_ruleset_names %}
 set zone-policy zone {{ target_zone }} from {{ zone.name }} firewall name {{ zone_ruleset }}
-{% else %}
-{% set query = "[?name=='"+target_zone+"' && from=='"+zone.name+"'].properties[].name" %}
-{% set router_zone_ruleset = router_zone_config_list | json_query(query) %}
-{% if router_zone_ruleset | length > 0 %}
-delete zone-policy zone {{ target_zone }} from {{ zone.name }} firewall name {{ zone_ruleset }}
-{% endif %}
 {% endif %}
 {% set zone_ruleset_v6 = zone.name+'-'+target_zone+'-v6' %}
 {% if zone_ruleset_v6 in firewall_ruleset_names %}
 set zone-policy zone {{ target_zone }} from {{ zone.name }} firewall ipv6-name {{ zone_ruleset_v6 }}
-{% else %}
-{% set query = "[?name=='"+target_zone+"' && from=='"+zone.name+"'].properties[].\"ipv6-name\"" %}
-{% set router_zone_ruleset = router_zone_config_list | json_query(query) %}
-{% if router_zone_ruleset | length > 0 %}
-delete zone-policy zone {{ target_zone }} from {{ zone.name }} firewall ipv6-name {{ zone_ruleset_v6 }}
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/templates/zones_firewall_cleanup.j2
+++ b/templates/zones_firewall_cleanup.j2
@@ -1,0 +1,25 @@
+{% set query = '[].name' %}
+{% set firewall_ruleset_names = firewall_rules_merged|json_query('[].name') | unique %}
+{% set zone_names = firewall_zones|default([]) | json_query('[].name') %}
+{% for zone in firewall_zones|default([]) %}
+{% for target_zone in zone_names %}
+{% set zone_ruleset = zone.name+'-'+target_zone %}
+{% if target_zone != zone.name %}
+{% if not zone_ruleset in firewall_ruleset_names %}
+{% set query = "[?name=='"+target_zone+"' && from=='"+zone.name+"'].properties[].name" %}
+{% set router_zone_ruleset = router_zone_config_list | json_query(query) %}
+{% if router_zone_ruleset | length > 0 %}
+delete zone-policy zone {{ target_zone }} from {{ zone.name }} firewall name {{ zone_ruleset }}
+{% endif %}
+{% endif %}
+{% set zone_ruleset_v6 = zone.name+'-'+target_zone+'-v6' %}
+{% if not zone_ruleset_v6 in firewall_ruleset_names %}
+{% set query = "[?name=='"+target_zone+"' && from=='"+zone.name+"'].properties[].\"ipv6-name\"" %}
+{% set router_zone_ruleset = router_zone_config_list | json_query(query) %}
+{% if router_zone_ruleset | length > 0 %}
+delete zone-policy zone {{ target_zone }} from {{ zone.name }} firewall ipv6-name {{ zone_ruleset_v6 }}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
Should fix an issue where deleting firewall rules could lead to a failure because there are zones that still use them